### PR TITLE
Handle all strings as utf-8 bytes (Buffers)

### DIFF
--- a/lib/pbkdf2.js
+++ b/lib/pbkdf2.js
@@ -7,6 +7,7 @@ function pbkdf2(key, salt, iterations, dkLen) {
   assert(typeof key == 'string' || Buffer.isBuffer(key), 'key must be a string or buffer')
   assert(typeof salt == 'string' || Buffer.isBuffer(salt), 'key must be a string or buffer')
 
+  if (typeof key == 'string') key = new Buffer(key)
   if (typeof salt == 'string') salt = new Buffer(salt)
 
   var DK = new Buffer(dkLen)


### PR DESCRIPTION
Notice how these are different.
```javascript
> var buf = new Buffer(32)
undefined
> buf.fill(255)
undefined
> buf
<Buffer ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff>
> c.createHmac('sha256', 'あ').update(buf).digest()
<SlowBuffer 07 33 71 74 91 d4 51 b0 e5 9b eb d9 a0 32 a6 69 34 c4 c9 5a 54 f6 dd ea da 50 28 f7 10 f0 61 35>
> c.createHmac('sha256', new Buffer('あ')).update(buf).digest()
<SlowBuffer 3e 2b 7b 53 31 04 3d 8a 24 ab bd 88 3a 61 6a 37 1d 28 ab 28 8a b5 81 e2 ad 17 26 28 19 bd 1a bb>
> c.createHmac('sha256', new Buffer('あ','utf8')).update(buf).digest()
<SlowBuffer 3e 2b 7b 53 31 04 3d 8a 24 ab bd 88 3a 61 6a 37 1d 28 ab 28 8a b5 81 e2 ad 17 26 28 19 bd 1a bb>
>
```
Would handling everything as utf8 go against pbkdf2 spec?